### PR TITLE
bumped ring to version 0.12.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ name = "ring_pwhash"
 [dependencies]
 libc = "0.2"
 data-encoding = "1"
-ring = "0.11"
+ring = "0.12.1"


### PR DESCRIPTION
to improve compatibility between crates that depend on the recent version of ring