### PR TITLE
Update to ring 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ name = "ring_pwhash"
 [dependencies]
 libc = "0.2"
 data-encoding = "2"
-ring = "0.12.1"
+ring = "0.13"


### PR DESCRIPTION
The change is trivial, but it makes it possible to use ring-pwhash together with ring 0.13. Currently, users of ring-pwhash are forced to use ring 0.12.